### PR TITLE
Added instructions for installation (and a missing library reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,50 @@
 
 - Web Technologies based Crossplatform GUI. https://juancarlospaco.github.io/webgui
 
+## Install
 
-# Buit-in Dark Mode
+Install webgui using the nimble tool.
 
-![](https://raw.githubusercontent.com/juancarlospaco/webgui/master/docs/darkui.png)
+```bash
+$ nimble install webgui
+```
+
+webgui also requires that your OS have the GTK+ 3.0 and webkit2gtk 4.0 packages installed.
+
+Generic instructions can be found at:
+
+* https://www.gtk.org/docs/installations/
+* https://webkitgtk.org/
+
+In Ubuntu (or Ubuntu-based distributions), these packages can be installed as follows:
+
+```bash
+$ sudo apt-get install gtk+-3.0
+$ sudo apt-get install webkit2gtk-4.0
+```
+
+## Buit-in Dark Mode
+
+![Dark mode](https://raw.githubusercontent.com/juancarlospaco/webgui/master/docs/darkui.png)
 
 
-# Buit-in Light Mode
+## Buit-in Light Mode
 
-![](https://raw.githubusercontent.com/juancarlospaco/webgui/master/docs/lightui.png)
-
-
-# Real Life Apps
-
-![](https://raw.githubusercontent.com/juancarlospaco/ballena-itcher/master/0.png)
+![Light mode](https://raw.githubusercontent.com/juancarlospaco/webgui/master/docs/lightui.png)
 
 
-![](https://raw.githubusercontent.com/juancarlospaco/nim-smnar/master/0.png)
+## Real Life Apps
+
+[![Ballena Itcher GUI](https://raw.githubusercontent.com/juancarlospaco/ballena-itcher/master/0.png)](https://github.com/juancarlospaco/ballena-itcher)
 
 
-![](https://user-images.githubusercontent.com/1189414/78953126-2f055c00-7aae-11ea-9570-4a5fcd5813bc.png)
+[![SMNAR GUI](https://raw.githubusercontent.com/juancarlospaco/nim-smnar/master/0.png)](https://github.com/juancarlospaco/nim-smnar)
 
 
-![](https://user-images.githubusercontent.com/1189414/78956916-36cafd80-7aba-11ea-97eb-75af94c99c80.png)
+![Example code](https://user-images.githubusercontent.com/1189414/78953126-2f055c00-7aae-11ea-9570-4a5fcd5813bc.png)
 
 
-![](https://raw.githubusercontent.com/ThomasTJdev/choosenim_gui/master/private/screenshot1.png)
+[![Nimble GUI](https://user-images.githubusercontent.com/1189414/78956916-36cafd80-7aba-11ea-97eb-75af94c99c80.png)](https://github.com/ThomasTJdev/nim_nimble_gui)
+
+
+[![Choosenim GUI](https://raw.githubusercontent.com/ThomasTJdev/choosenim_gui/master/private/screenshot1.png)](https://github.com/ThomasTJdev/choosenim_gui)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ $ sudo apt-get install webkit2gtk-4.0
 [![SMNAR GUI](https://raw.githubusercontent.com/juancarlospaco/nim-smnar/master/0.png)](https://github.com/juancarlospaco/nim-smnar)
 
 
-![Example code](https://user-images.githubusercontent.com/1189414/78953126-2f055c00-7aae-11ea-9570-4a5fcd5813bc.png)
+[![Nimble GUI](https://user-images.githubusercontent.com/1189414/78953126-2f055c00-7aae-11ea-9570-4a5fcd5813bc.png)](https://github.com/ThomasTJdev/nim_nimble_gui)
 
 
-[![Nimble GUI](https://user-images.githubusercontent.com/1189414/78956916-36cafd80-7aba-11ea-97eb-75af94c99c80.png)](https://github.com/ThomasTJdev/nim_nimble_gui)
+![example code](https://user-images.githubusercontent.com/1189414/78956916-36cafd80-7aba-11ea-97eb-75af94c99c80.png)
 
 
 [![Choosenim GUI](https://raw.githubusercontent.com/ThomasTJdev/choosenim_gui/master/private/screenshot1.png)](https://github.com/ThomasTJdev/choosenim_gui)

--- a/src/webgui.nim
+++ b/src/webgui.nim
@@ -39,7 +39,7 @@
 ## * https://github.com/juancarlospaco/nim-smnar      (**~32 lines of Nim** at the time of writing)
 ## * https://github.com/ThomasTJdev/choosenim_gui     (**~80 lines of Nim** at the time of writing)
 
-import tables, strutils, macros, json
+import tables, strutils, macros, json, os
 
 const headerC = currentSourcePath().substr(0, high(currentSourcePath()) - 10) & "webview.h"
 {.passC: "-DWEBVIEW_STATIC -DWEBVIEW_IMPLEMENTATION -I" & headerC.}


### PR DESCRIPTION
Since this library seems to require GTK+ 3.0 and webkit2gtk, I added helpful instructions to the README file.

And, on my machine anyway, I needed a library reference to `os` in order to see the `commandLineParams` procedure. I'm running PopOS! version 19.10, an Ubuntu variant, with Gnome 3.34.2 . Nim is on version 1.2.0.
