### PR TITLE
Fix linking on Windows

### DIFF
--- a/src/webgui.nim
+++ b/src/webgui.nim
@@ -54,7 +54,7 @@ const headerC = currentSourcePath().substr(0, high(currentSourcePath()) - 10) & 
 when defined(linux):
   {.passc: "-DWEBVIEW_GTK=1 " & staticExec"pkg-config --cflags gtk+-3.0 webkit2gtk-4.0", passl: staticExec"pkg-config --libs gtk+-3.0 webkit2gtk-4.0".}
 elif defined(windows):
-  {.passc: "-DWEBVIEW_WINAPI=1", passl: "-lole32 -lcomctl32 -loleaut32 -luuid -lgdi32".}
+  {.passc: "-DWEBVIEW_WINAPI=1", passl: "-lole32 -lcomctl32 -lcomdlg32 -loleaut32 -luuid -lgdi32".}
 elif defined(macosx):
   {.passc: "-DOBJC_OLD_DISPATCH_PROTOTYPES=1 -DWEBVIEW_COCOA=1 -x objective-c", passl: "-framework Cocoa -framework WebKit".}
 

--- a/src/webview.h
+++ b/src/webview.h
@@ -1499,7 +1499,7 @@ WEBVIEW_API void webview_set_iconify(struct webview *w, int iconify) {
 }
 
 WEBVIEW_API void webview_launch_external_URL(struct webview *w, const char *uri) {
-  ShellExecute(0, 0, uri, 0, 0 , SW_SHOW );
+  ShellExecuteW(0, 0, uri, 0, 0 , SW_SHOW );
 }
 
 WEBVIEW_API void webview_set_color(struct webview *w, uint8_t r, uint8_t g,


### PR DESCRIPTION
This fixes linking on Windows.

Tested on `ballena-itcher` (it doesn't really work on W7 with a bunch of js errors, probably due to an ancient browser engine, but at least now it compiles).

Closes #8